### PR TITLE
Use x64 on m1 for node versions smaller than 16

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,9 @@
   <body>
 
     <release version="3.0.6" date="not released">
+      <action type="update" dev="mschulze">
+        MacOS/aarch64: Use x64 NodeJS versions below 16.
+      </action>
       <action type="update" dev="sseifert">
         Declare maven core dependencies as provided.
       </action>

--- a/src/main/java/io/wcm/maven/plugins/nodejs/installation/NodeInstallationInformation.java
+++ b/src/main/java/io/wcm/maven/plugins/nodejs/installation/NodeInstallationInformation.java
@@ -140,8 +140,12 @@ public class NodeInstallationInformation {
       arch = "x64";
     }
     else if (Os.isArch("aarch64")) {
-      arch = "arm64";
-    }
+      if (Os.isFamily(Os.FAMILY_MAC) && Integer.parseInt(version.split("\\.")[0]) < 16) {
+          arch = "x64";
+        } else {
+          arch = "arm64";
+        }
+      }
     else {
       throw new MojoExecutionException("Unsupported OS arch: " + Os.OS_ARCH);
     }

--- a/src/main/java/io/wcm/maven/plugins/nodejs/installation/NodeInstallationInformation.java
+++ b/src/main/java/io/wcm/maven/plugins/nodejs/installation/NodeInstallationInformation.java
@@ -22,6 +22,8 @@ package io.wcm.maven.plugins.nodejs.installation;
 import java.io.File;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.codehaus.plexus.util.Os;
@@ -132,6 +134,8 @@ public class NodeInstallationInformation {
    * @throws MojoExecutionException Mojo execution exception
    */
   public static NodeInstallationInformation forVersion(String version, String npmVersion, File directory) throws MojoExecutionException {
+    int nodejsMajorVersion = getMajorVersion(version);
+
     String arch;
     if (Os.isArch("x86") || Os.isArch("i386")) {
       arch = "x86";
@@ -140,12 +144,13 @@ public class NodeInstallationInformation {
       arch = "x64";
     }
     else if (Os.isArch("aarch64")) {
-      if (Os.isFamily(Os.FAMILY_MAC) && Integer.parseInt(version.split("\\.")[0]) < 16) {
-          arch = "x64";
-        } else {
-          arch = "arm64";
-        }
+      if (Os.isFamily(Os.FAMILY_MAC) && nodejsMajorVersion < 16) {
+        arch = "x64";
       }
+      else {
+        arch = "arm64";
+      }
+    }
     else {
       throw new MojoExecutionException("Unsupported OS arch: " + Os.OS_ARCH);
     }
@@ -189,6 +194,11 @@ public class NodeInstallationInformation {
     }
 
     return result;
+  }
+
+  private static int getMajorVersion(String version) {
+    ArtifactVersion versionInfo = new DefaultArtifactVersion(version);
+    return versionInfo.getMajorVersion();
   }
 
   private static String getNodeModulesRootPathNpmSuffix(String npmVersion) {


### PR DESCRIPTION
There are no mac arm64 builds for nodejs below 16.