### PR TITLE
Improve File/Zip/Tar file I/O and security handling

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -28,6 +28,9 @@
       <action type="update" dev="sseifert">
         Switch to Java 21.
       </action>
+      <action type="fix" dev="sseifert" issue="58">
+        Improve File/Zip/Tar file I/O and security handling.
+      </action>
     </release>
 
     <release version="3.0.8" date="2024-06-04">

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,12 @@
       <version>4.0.3</version>
       <scope>compile</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/io/wcm/maven/plugins/nodejs/installation/SafeExtract.java
+++ b/src/main/java/io/wcm/maven/plugins/nodejs/installation/SafeExtract.java
@@ -1,0 +1,111 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2026 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.maven.plugins.nodejs.installation;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Path;
+
+/**
+ * Helper to mitigate zip slip and zip bomb attacks during archive extraction.
+ *
+ * <p>
+ * Apache Commons Compress does not perform these checks itself; callers are
+ * expected to implement them. See:
+ * <ul>
+ * <li><a href="https://commons.apache.org/proper/commons-compress/security-reports.html">
+ * Apache Commons Compress security recommendations</a></li>
+ * <li><a href="https://rules.sonarsource.com/java/RSPEC-5042">
+ * SonarSource rule java:S5042 (Expanding archive files without controlling resource consumption is
+ * security-sensitive)</a></li>
+ * <li><a href="https://snyk.io/research/zip-slip-vulnerability">
+ * Snyk: Zip Slip vulnerability</a></li>
+ * </ul>
+ * </p>
+ */
+final class SafeExtract {
+
+  /** Maximum total uncompressed size of an extracted archive (1 GB). */
+  static final long MAX_TOTAL_UNCOMPRESSED_BYTES = 1024L * 1024L * 1024L;
+  /** Maximum number of entries in an archive. */
+  static final long MAX_ENTRIES = 100_000L;
+
+  private static final int BUFFER_SIZE = 8192;
+
+  private SafeExtract() {
+    // static helper
+  }
+
+  /**
+   * Resolve an entry path against the target base directory and ensure it stays inside it
+   * (mitigates zip slip).
+   * @param baseDir target base directory (normalized, absolute)
+   * @param entryName archive entry name
+   * @return resolved, normalized destination path
+   * @throws IOException if the entry would escape the base directory
+   */
+  static Path resolveSafely(Path baseDir, String entryName) throws IOException {
+    Path normalizedBase = baseDir.toAbsolutePath().normalize();
+    Path resolved = normalizedBase.resolve(entryName).normalize();
+    if (!resolved.startsWith(normalizedBase)) {
+      throw new IOException("Archive entry is outside of the target directory: " + entryName);
+    }
+    return resolved;
+  }
+
+  /**
+   * Copy data from an archive entry stream while enforcing the global byte limit
+   * (mitigates zip bomb).
+   * @param in archive entry input stream
+   * @param out destination stream
+   * @param bytesWrittenSoFar bytes already written for the current archive
+   * @return new total of bytes written
+   * @throws IOException if the limit is exceeded
+   */
+  static long copyWithLimit(InputStream in, OutputStream out, long bytesWrittenSoFar) throws IOException {
+    byte[] buffer = new byte[BUFFER_SIZE];
+    long total = bytesWrittenSoFar;
+    int n = in.read(buffer);
+    while (n != -1) {
+      total += n;
+      if (total > MAX_TOTAL_UNCOMPRESSED_BYTES) {
+        throw new IOException("Archive uncompressed size exceeds limit of "
+            + MAX_TOTAL_UNCOMPRESSED_BYTES + " bytes (possible zip bomb)");
+      }
+      out.write(buffer, 0, n);
+      n = in.read(buffer);
+    }
+    return total;
+  }
+
+  /**
+   * Check that the number of processed entries does not exceed the limit.
+   * @param entryCount current entry count
+   * @throws IOException if the limit is exceeded
+   */
+  static void checkEntryCount(long entryCount) throws IOException {
+    if (entryCount > MAX_ENTRIES) {
+      throw new IOException("Archive contains more than " + MAX_ENTRIES
+          + " entries (possible zip bomb)");
+    }
+  }
+
+}

--- a/src/main/java/io/wcm/maven/plugins/nodejs/installation/TarUnArchiver.java
+++ b/src/main/java/io/wcm/maven/plugins/nodejs/installation/TarUnArchiver.java
@@ -22,10 +22,11 @@ package io.wcm.maven.plugins.nodejs.installation;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
 
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
@@ -58,20 +59,30 @@ public class TarUnArchiver {
       TarArchiveEntry tarEntry = tarIn.getNextEntry();
       while (tarEntry != null) {
         // Create a file for this tarEntry
-        final File destPath = new File(baseDir + File.separator + tarEntry.getName());
+        final Path destPath = Path.of(baseDir, tarEntry.getName());
         if (tarEntry.isSymbolicLink()) {
-          Path linkPath = destPath.toPath();
-          Path targetPath = new File(tarEntry.getLinkName()).toPath();
-          Files.createSymbolicLink(linkPath, targetPath);
+          Path targetPath = Path.of(tarEntry.getLinkName());
+          Files.createSymbolicLink(destPath, targetPath);
         }
         else if (tarEntry.isDirectory()) {
-          destPath.mkdirs();
+          Files.createDirectories(destPath);
         }
         else {
-          destPath.createNewFile();
-          destPath.setExecutable(true);
-          try (BufferedOutputStream bout = new BufferedOutputStream(new FileOutputStream(destPath))) {
+          if (destPath.getParent() != null) {
+            Files.createDirectories(destPath.getParent());
+          }
+          try (BufferedOutputStream bout = new BufferedOutputStream(Files.newOutputStream(destPath))) {
             IOUtils.copy(tarIn, bout);
+          }
+          // set executable permission via PosixFilePermissions when supported
+          try {
+            Set<PosixFilePermission> perms = Files.getPosixFilePermissions(destPath);
+            perms.add(PosixFilePermission.OWNER_EXECUTE);
+            perms.add(PosixFilePermission.GROUP_EXECUTE);
+            Files.setPosixFilePermissions(destPath, perms);
+          }
+          catch (UnsupportedOperationException ex) {
+            // not a POSIX file system (e.g. Windows) - skip setting permissions
           }
         }
         tarEntry = tarIn.getNextEntry();
@@ -82,7 +93,12 @@ public class TarUnArchiver {
     }
 
     // delete archive after extraction
-    archive.delete();
+    try {
+      Files.deleteIfExists(archive.toPath());
+    }
+    catch (IOException ex) {
+      throw new MojoExecutionException("Could not delete archive: " + archive.getAbsolutePath(), ex);
+    }
   }
 
 }

--- a/src/main/java/io/wcm/maven/plugins/nodejs/installation/TarUnArchiver.java
+++ b/src/main/java/io/wcm/maven/plugins/nodejs/installation/TarUnArchiver.java
@@ -62,56 +62,9 @@ public class TarUnArchiver {
    */
   public void unarchive(String baseDir) throws MojoExecutionException {
     Path baseDirPath = Path.of(baseDir);
-    long entryCount = 0;
-    long totalBytes = 0;
     try (FileInputStream fis = new FileInputStream(archive);
         TarArchiveInputStream tarIn = new TarArchiveInputStream(new GzipCompressorInputStream(fis))) {
-      TarArchiveEntry tarEntry = tarIn.getNextEntry();
-      while (tarEntry != null) {
-        entryCount++;
-        SafeExtract.checkEntryCount(entryCount);
-        // resolve safely against the base directory (mitigates zip slip)
-        final Path destPath = SafeExtract.resolveSafely(baseDirPath, tarEntry.getName());
-        if (tarEntry.isSymbolicLink()) {
-          // ensure symlink target stays within the base directory.
-          // Symlink targets are typically relative to the directory containing the symlink,
-          // so resolve them against the symlink's parent directory but verify the final
-          // location against the extraction base directory.
-          Path linkParent = destPath.getParent() != null ? destPath.getParent() : baseDirPath;
-          Path resolvedLinkTarget = linkParent.resolve(tarEntry.getLinkName()).normalize();
-          if (!resolvedLinkTarget.startsWith(baseDirPath.toAbsolutePath().normalize())) {
-            throw new IOException("Symbolic link target is outside of the target directory: "
-                + tarEntry.getName() + " -> " + tarEntry.getLinkName());
-          }
-          if (destPath.getParent() != null) {
-            Files.createDirectories(destPath.getParent());
-          }
-          Path targetPath = Path.of(tarEntry.getLinkName());
-          Files.createSymbolicLink(destPath, targetPath);
-        }
-        else if (tarEntry.isDirectory()) {
-          Files.createDirectories(destPath);
-        }
-        else {
-          if (destPath.getParent() != null) {
-            Files.createDirectories(destPath.getParent());
-          }
-          try (OutputStream bout = new BufferedOutputStream(Files.newOutputStream(destPath))) {
-            totalBytes = SafeExtract.copyWithLimit(tarIn, bout, totalBytes);
-          }
-          // set executable permission via PosixFilePermissions when supported
-          try {
-            Set<PosixFilePermission> perms = Files.getPosixFilePermissions(destPath);
-            perms.add(PosixFilePermission.OWNER_EXECUTE);
-            perms.add(PosixFilePermission.GROUP_EXECUTE);
-            Files.setPosixFilePermissions(destPath, perms);
-          }
-          catch (UnsupportedOperationException ex) {
-            // not a POSIX file system (e.g. Windows) - skip setting permissions
-          }
-        }
-        tarEntry = tarIn.getNextEntry();
-      }
+      extractEntries(tarIn, baseDirPath);
     }
     catch (IOException ex) {
       throw new MojoExecutionException("Could not extract archive: " + archive.getAbsolutePath(), ex);
@@ -123,6 +76,70 @@ public class TarUnArchiver {
     }
     catch (IOException ex) {
       throw new MojoExecutionException("Could not delete archive: " + archive.getAbsolutePath(), ex);
+    }
+  }
+
+  private static void extractEntries(TarArchiveInputStream tarIn, Path baseDirPath) throws IOException {
+    long entryCount = 0;
+    long totalBytes = 0;
+    TarArchiveEntry tarEntry = tarIn.getNextEntry();
+    while (tarEntry != null) {
+      entryCount++;
+      SafeExtract.checkEntryCount(entryCount);
+      // resolve safely against the base directory (mitigates zip slip)
+      final Path destPath = SafeExtract.resolveSafely(baseDirPath, tarEntry.getName());
+      if (tarEntry.isSymbolicLink()) {
+        extractSymbolicLink(tarEntry, destPath, baseDirPath);
+      }
+      else if (tarEntry.isDirectory()) {
+        Files.createDirectories(destPath);
+      }
+      else {
+        totalBytes = extractFile(tarIn, destPath, totalBytes);
+      }
+      tarEntry = tarIn.getNextEntry();
+    }
+  }
+
+  private static void extractSymbolicLink(TarArchiveEntry tarEntry, Path destPath, Path baseDirPath) throws IOException {
+    // ensure symlink target stays within the base directory.
+    // Symlink targets are typically relative to the directory containing the symlink,
+    // so resolve them against the symlink's parent directory but verify the final
+    // location against the extraction base directory.
+    Path linkParent = destPath.getParent() != null ? destPath.getParent() : baseDirPath;
+    Path resolvedLinkTarget = linkParent.resolve(tarEntry.getLinkName()).normalize();
+    if (!resolvedLinkTarget.startsWith(baseDirPath.toAbsolutePath().normalize())) {
+      throw new IOException("Symbolic link target is outside of the target directory: "
+          + tarEntry.getName() + " -> " + tarEntry.getLinkName());
+    }
+    if (destPath.getParent() != null) {
+      Files.createDirectories(destPath.getParent());
+    }
+    Files.createSymbolicLink(destPath, Path.of(tarEntry.getLinkName()));
+  }
+
+  private static long extractFile(TarArchiveInputStream tarIn, Path destPath, long totalBytes) throws IOException {
+    if (destPath.getParent() != null) {
+      Files.createDirectories(destPath.getParent());
+    }
+    long newTotal;
+    try (OutputStream bout = new BufferedOutputStream(Files.newOutputStream(destPath))) {
+      newTotal = SafeExtract.copyWithLimit(tarIn, bout, totalBytes);
+    }
+    setExecutablePermissionsIfPosix(destPath);
+    return newTotal;
+  }
+
+  private static void setExecutablePermissionsIfPosix(Path destPath) throws IOException {
+    // set executable permission via PosixFilePermissions when supported
+    try {
+      Set<PosixFilePermission> perms = Files.getPosixFilePermissions(destPath);
+      perms.add(PosixFilePermission.OWNER_EXECUTE);
+      perms.add(PosixFilePermission.GROUP_EXECUTE);
+      Files.setPosixFilePermissions(destPath, perms);
+    }
+    catch (UnsupportedOperationException ex) {
+      // not a POSIX file system (e.g. Windows) - skip setting permissions
     }
   }
 

--- a/src/main/java/io/wcm/maven/plugins/nodejs/installation/TarUnArchiver.java
+++ b/src/main/java/io/wcm/maven/plugins/nodejs/installation/TarUnArchiver.java
@@ -73,9 +73,19 @@ public class TarUnArchiver {
         // resolve safely against the base directory (mitigates zip slip)
         final Path destPath = SafeExtract.resolveSafely(baseDirPath, tarEntry.getName());
         if (tarEntry.isSymbolicLink()) {
-          // ensure symlink target also stays within the base directory
-          SafeExtract.resolveSafely(destPath.getParent() != null ? destPath.getParent() : baseDirPath,
-              tarEntry.getLinkName());
+          // ensure symlink target stays within the base directory.
+          // Symlink targets are typically relative to the directory containing the symlink,
+          // so resolve them against the symlink's parent directory but verify the final
+          // location against the extraction base directory.
+          Path linkParent = destPath.getParent() != null ? destPath.getParent() : baseDirPath;
+          Path resolvedLinkTarget = linkParent.resolve(tarEntry.getLinkName()).normalize();
+          if (!resolvedLinkTarget.startsWith(baseDirPath.toAbsolutePath().normalize())) {
+            throw new IOException("Symbolic link target is outside of the target directory: "
+                + tarEntry.getName() + " -> " + tarEntry.getLinkName());
+          }
+          if (destPath.getParent() != null) {
+            Files.createDirectories(destPath.getParent());
+          }
           Path targetPath = Path.of(tarEntry.getLinkName());
           Files.createSymbolicLink(destPath, targetPath);
         }

--- a/src/main/java/io/wcm/maven/plugins/nodejs/installation/TarUnArchiver.java
+++ b/src/main/java/io/wcm/maven/plugins/nodejs/installation/TarUnArchiver.java
@@ -106,21 +106,23 @@ public class TarUnArchiver {
     // Symlink targets are typically relative to the directory containing the symlink,
     // so resolve them against the symlink's parent directory but verify the final
     // location against the extraction base directory.
-    Path linkParent = destPath.getParent() != null ? destPath.getParent() : baseDirPath;
+    Path destParent = destPath.getParent();
+    Path linkParent = destParent != null ? destParent : baseDirPath;
     Path resolvedLinkTarget = linkParent.resolve(tarEntry.getLinkName()).normalize();
     if (!resolvedLinkTarget.startsWith(baseDirPath.toAbsolutePath().normalize())) {
       throw new IOException("Symbolic link target is outside of the target directory: "
           + tarEntry.getName() + " -> " + tarEntry.getLinkName());
     }
-    if (destPath.getParent() != null) {
-      Files.createDirectories(destPath.getParent());
+    if (destParent != null) {
+      Files.createDirectories(destParent);
     }
     Files.createSymbolicLink(destPath, Path.of(tarEntry.getLinkName()));
   }
 
   private static long extractFile(TarArchiveInputStream tarIn, Path destPath, long totalBytes) throws IOException {
-    if (destPath.getParent() != null) {
-      Files.createDirectories(destPath.getParent());
+    Path destParent = destPath.getParent();
+    if (destParent != null) {
+      Files.createDirectories(destParent);
     }
     long newTotal;
     try (OutputStream bout = new BufferedOutputStream(Files.newOutputStream(destPath))) {

--- a/src/main/java/io/wcm/maven/plugins/nodejs/installation/TarUnArchiver.java
+++ b/src/main/java/io/wcm/maven/plugins/nodejs/installation/TarUnArchiver.java
@@ -23,6 +23,7 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
@@ -31,11 +32,17 @@ import java.util.Set;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
-import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 
 /**
- * Wrapper around the commons compress library to decompress the zipped tar archives
+ * Wrapper around the commons compress library to decompress the zipped tar archives.
+ *
+ * <p>
+ * Extraction is hardened against zip slip and zip bomb attacks via {@link SafeExtract}.
+ * See <a href="https://commons.apache.org/proper/commons-compress/security-reports.html">
+ * Commons Compress security recommendations</a> and
+ * <a href="https://rules.sonarsource.com/java/RSPEC-5042">SonarSource rule java:S5042</a>.
+ * </p>
  */
 public class TarUnArchiver {
 
@@ -54,13 +61,21 @@ public class TarUnArchiver {
    * @throws MojoExecutionException Mojo execution exception
    */
   public void unarchive(String baseDir) throws MojoExecutionException {
+    Path baseDirPath = Path.of(baseDir);
+    long entryCount = 0;
+    long totalBytes = 0;
     try (FileInputStream fis = new FileInputStream(archive);
         TarArchiveInputStream tarIn = new TarArchiveInputStream(new GzipCompressorInputStream(fis))) {
       TarArchiveEntry tarEntry = tarIn.getNextEntry();
       while (tarEntry != null) {
-        // Create a file for this tarEntry
-        final Path destPath = Path.of(baseDir, tarEntry.getName());
+        entryCount++;
+        SafeExtract.checkEntryCount(entryCount);
+        // resolve safely against the base directory (mitigates zip slip)
+        final Path destPath = SafeExtract.resolveSafely(baseDirPath, tarEntry.getName());
         if (tarEntry.isSymbolicLink()) {
+          // ensure symlink target also stays within the base directory
+          SafeExtract.resolveSafely(destPath.getParent() != null ? destPath.getParent() : baseDirPath,
+              tarEntry.getLinkName());
           Path targetPath = Path.of(tarEntry.getLinkName());
           Files.createSymbolicLink(destPath, targetPath);
         }
@@ -71,8 +86,8 @@ public class TarUnArchiver {
           if (destPath.getParent() != null) {
             Files.createDirectories(destPath.getParent());
           }
-          try (BufferedOutputStream bout = new BufferedOutputStream(Files.newOutputStream(destPath))) {
-            IOUtils.copy(tarIn, bout);
+          try (OutputStream bout = new BufferedOutputStream(Files.newOutputStream(destPath))) {
+            totalBytes = SafeExtract.copyWithLimit(tarIn, bout, totalBytes);
           }
           // set executable permission via PosixFilePermissions when supported
           try {

--- a/src/main/java/io/wcm/maven/plugins/nodejs/installation/ZipUnArchiver.java
+++ b/src/main/java/io/wcm/maven/plugins/nodejs/installation/ZipUnArchiver.java
@@ -23,16 +23,23 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
-import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 
 /**
- * Wrapper around the commons compress library to decompress the zip archives
+ * Wrapper around the commons compress library to decompress the zip archives.
+ *
+ * <p>
+ * Extraction is hardened against zip slip and zip bomb attacks via {@link SafeExtract}.
+ * See <a href="https://commons.apache.org/proper/commons-compress/security-reports.html">
+ * Commons Compress security recommendations</a> and
+ * <a href="https://rules.sonarsource.com/java/RSPEC-5042">SonarSource rule java:S5042</a>.
+ * </p>
  */
 public class ZipUnArchiver {
 
@@ -51,12 +58,17 @@ public class ZipUnArchiver {
    * @throws MojoExecutionException Mojo execution exception
    */
   public void unarchive(String baseDir) throws MojoExecutionException {
+    Path baseDirPath = Path.of(baseDir);
+    long entryCount = 0;
+    long totalBytes = 0;
     try (FileInputStream fis = new FileInputStream(archive);
         ZipArchiveInputStream zipIn = new ZipArchiveInputStream(fis)) {
       ZipArchiveEntry zipEntry = zipIn.getNextEntry();
       while (zipEntry != null) {
-        // Create a file for this zipEntry
-        final Path destPath = Path.of(baseDir, zipEntry.getName());
+        entryCount++;
+        SafeExtract.checkEntryCount(entryCount);
+        // resolve safely against the base directory (mitigates zip slip)
+        final Path destPath = SafeExtract.resolveSafely(baseDirPath, zipEntry.getName());
         if (zipEntry.isDirectory()) {
           Files.createDirectories(destPath);
         }
@@ -64,8 +76,8 @@ public class ZipUnArchiver {
           if (destPath.getParent() != null) {
             Files.createDirectories(destPath.getParent());
           }
-          try (BufferedOutputStream bout = new BufferedOutputStream(Files.newOutputStream(destPath))) {
-            IOUtils.copy(zipIn, bout);
+          try (OutputStream bout = new BufferedOutputStream(Files.newOutputStream(destPath))) {
+            totalBytes = SafeExtract.copyWithLimit(zipIn, bout, totalBytes);
           }
         }
         zipEntry = zipIn.getNextEntry();

--- a/src/main/java/io/wcm/maven/plugins/nodejs/installation/ZipUnArchiver.java
+++ b/src/main/java/io/wcm/maven/plugins/nodejs/installation/ZipUnArchiver.java
@@ -22,8 +22,9 @@ package io.wcm.maven.plugins.nodejs.installation;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
@@ -52,20 +53,22 @@ public class ZipUnArchiver {
   public void unarchive(String baseDir) throws MojoExecutionException {
     try (FileInputStream fis = new FileInputStream(archive);
         ZipArchiveInputStream zipIn = new ZipArchiveInputStream(fis)) {
-      ZipArchiveEntry zipEnry = zipIn.getNextEntry();
-      while (zipEnry != null) {
-        // Create a file for this tarEntry
-        final File destPath = new File(baseDir + File.separator + zipEnry.getName());
-        if (zipEnry.isDirectory()) {
-          destPath.mkdirs();
+      ZipArchiveEntry zipEntry = zipIn.getNextEntry();
+      while (zipEntry != null) {
+        // Create a file for this zipEntry
+        final Path destPath = Path.of(baseDir, zipEntry.getName());
+        if (zipEntry.isDirectory()) {
+          Files.createDirectories(destPath);
         }
         else {
-          destPath.createNewFile();
-          try (BufferedOutputStream bout = new BufferedOutputStream(new FileOutputStream(destPath))) {
+          if (destPath.getParent() != null) {
+            Files.createDirectories(destPath.getParent());
+          }
+          try (BufferedOutputStream bout = new BufferedOutputStream(Files.newOutputStream(destPath))) {
             IOUtils.copy(zipIn, bout);
           }
         }
-        zipEnry = zipIn.getNextEntry();
+        zipEntry = zipIn.getNextEntry();
       }
     }
     catch (IOException ex) {
@@ -73,7 +76,12 @@ public class ZipUnArchiver {
     }
 
     // delete archive after extraction
-    archive.delete();
+    try {
+      Files.deleteIfExists(archive.toPath());
+    }
+    catch (IOException ex) {
+      throw new MojoExecutionException("Could not delete archive: " + archive.getAbsolutePath(), ex);
+    }
   }
 
 }

--- a/src/main/java/io/wcm/maven/plugins/nodejs/installation/ZipUnArchiver.java
+++ b/src/main/java/io/wcm/maven/plugins/nodejs/installation/ZipUnArchiver.java
@@ -73,8 +73,9 @@ public class ZipUnArchiver {
           Files.createDirectories(destPath);
         }
         else {
-          if (destPath.getParent() != null) {
-            Files.createDirectories(destPath.getParent());
+          Path destParent = destPath.getParent();
+          if (destParent != null) {
+            Files.createDirectories(destParent);
           }
           try (OutputStream bout = new BufferedOutputStream(Files.newOutputStream(destPath))) {
             totalBytes = SafeExtract.copyWithLimit(zipIn, bout, totalBytes);

--- a/src/main/java/io/wcm/maven/plugins/nodejs/mojo/Task.java
+++ b/src/main/java/io/wcm/maven/plugins/nodejs/mojo/Task.java
@@ -21,6 +21,7 @@ package io.wcm.maven.plugins.nodejs.mojo;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 
@@ -54,7 +55,12 @@ public class Task {
     ProcessBuilder processBuilder = new ProcessBuilder(getCommand(information));
     if (workingDirectory != null) {
       if (!workingDirectory.exists()) {
-        workingDirectory.mkdir();
+        try {
+          Files.createDirectories(workingDirectory.toPath());
+        }
+        catch (IOException ex) {
+          throw new MojoExecutionException("Could not create working directory: " + workingDirectory.getAbsolutePath(), ex);
+        }
       }
       processBuilder.directory(workingDirectory);
     }

--- a/src/test/java/io/wcm/maven/plugins/nodejs/installation/SafeExtractTest.java
+++ b/src/test/java/io/wcm/maven/plugins/nodejs/installation/SafeExtractTest.java
@@ -1,0 +1,129 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2026 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.maven.plugins.nodejs.installation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SafeExtractTest {
+
+  @Test
+  void testResolveSafely_validEntry(@TempDir Path tempDir) throws IOException {
+    Path resolved = SafeExtract.resolveSafely(tempDir, "subdir/file.txt");
+    assertTrue(resolved.startsWith(tempDir.toAbsolutePath().normalize()));
+    assertTrue(resolved.endsWith(Path.of("subdir", "file.txt")));
+  }
+
+  @Test
+  void testResolveSafely_validNestedEntry(@TempDir Path tempDir) throws IOException {
+    Path resolved = SafeExtract.resolveSafely(tempDir, "a/b/c/d.txt");
+    assertTrue(resolved.startsWith(tempDir.toAbsolutePath().normalize()));
+  }
+
+  @Test
+  void testResolveSafely_zipSlipParentEscape(@TempDir Path tempDir) {
+    IOException ex = assertThrows(IOException.class,
+        () -> SafeExtract.resolveSafely(tempDir, "../../../etc/passwd"));
+    assertTrue(ex.getMessage().contains("outside of the target directory"));
+  }
+
+  @Test
+  void testResolveSafely_zipSlipDeepParentEscape(@TempDir Path tempDir) {
+    // many parent-references should always escape
+    assertThrows(IOException.class,
+        () -> SafeExtract.resolveSafely(tempDir, "../../../../../../evil.txt"));
+  }
+
+  @Test
+  void testResolveSafely_subdirParentRefStillInside(@TempDir Path tempDir) throws IOException {
+    // entry that uses .. but stays inside the base directory must be allowed
+    Path resolved = SafeExtract.resolveSafely(tempDir, "a/b/../c.txt");
+    assertTrue(resolved.startsWith(tempDir.toAbsolutePath().normalize()));
+    assertTrue(resolved.endsWith(Path.of("a", "c.txt")));
+  }
+
+  @Test
+  void testCopyWithLimit_copiesAllBytes() throws IOException {
+    byte[] data = "Hello, World!".getBytes();
+    ByteArrayInputStream in = new ByteArrayInputStream(data);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    long total = SafeExtract.copyWithLimit(in, out, 0L);
+    assertEquals(data.length, total);
+    assertEquals("Hello, World!", out.toString());
+  }
+
+  @Test
+  void testCopyWithLimit_accumulatesPriorTotal() throws IOException {
+    byte[] data = new byte[100];
+    ByteArrayInputStream in = new ByteArrayInputStream(data);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    long total = SafeExtract.copyWithLimit(in, out, 500L);
+    assertEquals(600L, total);
+  }
+
+  @Test
+  void testCopyWithLimit_exceedsLimit() {
+    // start near the limit so a small input pushes us over
+    byte[] data = new byte[200];
+    ByteArrayInputStream in = new ByteArrayInputStream(data);
+    OutputStream out = OutputStream.nullOutputStream();
+    long startTotal = SafeExtract.MAX_TOTAL_UNCOMPRESSED_BYTES - 50L;
+    IOException ex = assertThrows(IOException.class,
+        () -> SafeExtract.copyWithLimit(in, out, startTotal));
+    assertTrue(ex.getMessage().contains("possible zip bomb"));
+  }
+
+  @Test
+  void testCopyWithLimit_exactlyAtLimitOk() throws IOException {
+    // writing exactly to the limit should NOT throw (strict greater-than check)
+    int chunk = 100;
+    InputStream in = new ByteArrayInputStream(new byte[chunk]);
+    OutputStream out = OutputStream.nullOutputStream();
+    long startTotal = SafeExtract.MAX_TOTAL_UNCOMPRESSED_BYTES - chunk;
+    long total = SafeExtract.copyWithLimit(in, out, startTotal);
+    assertEquals(SafeExtract.MAX_TOTAL_UNCOMPRESSED_BYTES, total);
+  }
+
+  @Test
+  void testCheckEntryCount_underLimit() throws IOException {
+    SafeExtract.checkEntryCount(0L);
+    SafeExtract.checkEntryCount(1L);
+    SafeExtract.checkEntryCount(SafeExtract.MAX_ENTRIES);
+  }
+
+  @Test
+  void testCheckEntryCount_overLimit() {
+    IOException ex = assertThrows(IOException.class,
+        () -> SafeExtract.checkEntryCount(SafeExtract.MAX_ENTRIES + 1));
+    assertTrue(ex.getMessage().contains("possible zip bomb"));
+  }
+
+}

--- a/src/test/java/io/wcm/maven/plugins/nodejs/installation/TarUnArchiverTest.java
+++ b/src/test/java/io/wcm/maven/plugins/nodejs/installation/TarUnArchiverTest.java
@@ -1,0 +1,124 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2026 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.maven.plugins.nodejs.installation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.archivers.tar.TarConstants;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TarUnArchiverTest {
+
+  private static final String FILE_CONTENT = "hello tar";
+
+  @Test
+  void testUnarchive_validTarGz(@TempDir Path tempDir) throws IOException, MojoExecutionException {
+    File archive = tempDir.resolve("test.tar.gz").toFile();
+    try (TarArchiveOutputStream tos = newTarGz(archive)) {
+      addDirEntry(tos, "subdir/");
+      addFileEntry(tos, "subdir/file.txt", FILE_CONTENT.getBytes(StandardCharsets.UTF_8));
+      addFileEntry(tos, "root.txt", "root".getBytes(StandardCharsets.UTF_8));
+    }
+
+    Path target = tempDir.resolve("out");
+    Files.createDirectories(target);
+    new TarUnArchiver(archive).unarchive(target.toString());
+
+    assertTrue(Files.isDirectory(target.resolve("subdir")));
+    assertEquals(FILE_CONTENT, Files.readString(target.resolve("subdir/file.txt")));
+    assertEquals("root", Files.readString(target.resolve("root.txt")));
+    // archive must be deleted after extraction
+    assertFalse(archive.exists());
+  }
+
+  @Test
+  void testUnarchive_zipSlipRejected(@TempDir Path tempDir) throws IOException {
+    File archive = tempDir.resolve("evil.tar.gz").toFile();
+    try (TarArchiveOutputStream tos = newTarGz(archive)) {
+      addFileEntry(tos, "../../evil.txt", "boom".getBytes(StandardCharsets.UTF_8));
+    }
+
+    Path target = tempDir.resolve("out");
+    Files.createDirectories(target);
+    MojoExecutionException ex = assertThrows(MojoExecutionException.class,
+        () -> new TarUnArchiver(archive).unarchive(target.toString()));
+    assertTrue(ex.getCause() instanceof IOException);
+    assertTrue(ex.getCause().getMessage().contains("outside of the target directory"));
+    assertFalse(Files.exists(tempDir.resolve("evil.txt")));
+    assertFalse(Files.exists(tempDir.getParent().resolve("evil.txt")));
+  }
+
+  @Test
+  void testUnarchive_symlinkEscapeRejected(@TempDir Path tempDir) throws IOException {
+    File archive = tempDir.resolve("symlink-evil.tar.gz").toFile();
+    try (TarArchiveOutputStream tos = newTarGz(archive)) {
+      TarArchiveEntry entry = new TarArchiveEntry("link", TarConstants.LF_SYMLINK);
+      // symlink target attempts to escape the destination directory
+      entry.setLinkName("../../../../etc/passwd");
+      tos.putArchiveEntry(entry);
+      tos.closeArchiveEntry();
+    }
+
+    Path target = tempDir.resolve("out");
+    Files.createDirectories(target);
+    MojoExecutionException ex = assertThrows(MojoExecutionException.class,
+        () -> new TarUnArchiver(archive).unarchive(target.toString()));
+    assertTrue(ex.getCause() instanceof IOException);
+    assertTrue(ex.getCause().getMessage().contains("outside of the target directory"));
+    // symlink itself must not have been created
+    assertFalse(Files.exists(target.resolve("link"), java.nio.file.LinkOption.NOFOLLOW_LINKS));
+  }
+
+  private static TarArchiveOutputStream newTarGz(File archive) throws IOException {
+    OutputStream fos = new FileOutputStream(archive);
+    return new TarArchiveOutputStream(new GzipCompressorOutputStream(fos));
+  }
+
+  private static void addFileEntry(TarArchiveOutputStream tos, String name, byte[] data) throws IOException {
+    TarArchiveEntry entry = new TarArchiveEntry(name);
+    entry.setSize(data.length);
+    tos.putArchiveEntry(entry);
+    tos.write(data);
+    tos.closeArchiveEntry();
+  }
+
+  private static void addDirEntry(TarArchiveOutputStream tos, String name) throws IOException {
+    TarArchiveEntry entry = new TarArchiveEntry(name);
+    tos.putArchiveEntry(entry);
+    tos.closeArchiveEntry();
+  }
+
+}

--- a/src/test/java/io/wcm/maven/plugins/nodejs/installation/TarUnArchiverTest.java
+++ b/src/test/java/io/wcm/maven/plugins/nodejs/installation/TarUnArchiverTest.java
@@ -81,15 +81,50 @@ class TarUnArchiverTest {
     assertFalse(Files.exists(tempDir.getParent().resolve("evil.txt")));
   }
 
+  /**
+   * Regression test for the bug that rejected legitimate intra-archive relative symlinks such as
+   * the ones found in real Node.js distributions:
+   * bin/npm -> ../lib/node_modules/npm/bin/npm-cli.js
+   * The link target crosses a sibling directory boundary but remains inside the extraction root,
+   * so it must be accepted.
+   */
+  @Test
+  void testUnarchive_legitimateRelativeSymlink(@TempDir Path tempDir) throws IOException, MojoExecutionException {
+    File archive = tempDir.resolve("node-like.tar.gz").toFile();
+    byte[] scriptContent = "#!/usr/bin/env node".getBytes(StandardCharsets.UTF_8);
+    try (TarArchiveOutputStream tos = newTarGz(archive)) {
+      addDirEntry(tos, "node-v14/");
+      addDirEntry(tos, "node-v14/bin/");
+      addDirEntry(tos, "node-v14/lib/");
+      addDirEntry(tos, "node-v14/lib/node_modules/");
+      addDirEntry(tos, "node-v14/lib/node_modules/npm/");
+      addDirEntry(tos, "node-v14/lib/node_modules/npm/bin/");
+      addFileEntry(tos, "node-v14/lib/node_modules/npm/bin/npm-cli.js", scriptContent);
+      // This is the exact pattern used by Node.js tarballs:
+      //   node-v14/bin/npm -> ../lib/node_modules/npm/bin/npm-cli.js
+      addSymlinkEntry(tos, "node-v14/bin/npm", "../lib/node_modules/npm/bin/npm-cli.js");
+    }
+
+    Path target = tempDir.resolve("out");
+    Files.createDirectories(target);
+    // Must NOT throw – this was the bug
+    new TarUnArchiver(archive).unarchive(target.toString());
+
+    // The actual symlink file must have been created
+    Path symlink = target.resolve("node-v14/bin/npm");
+    assertTrue(Files.exists(symlink, java.nio.file.LinkOption.NOFOLLOW_LINKS),
+        "symlink node-v14/bin/npm must exist");
+    assertTrue(Files.isSymbolicLink(symlink), "node-v14/bin/npm must be a symlink");
+    assertEquals("../lib/node_modules/npm/bin/npm-cli.js",
+        Files.readSymbolicLink(symlink).toString().replace('\\', '/'),
+        "symlink target must be preserved verbatim");
+  }
+
   @Test
   void testUnarchive_symlinkEscapeRejected(@TempDir Path tempDir) throws IOException {
     File archive = tempDir.resolve("symlink-evil.tar.gz").toFile();
     try (TarArchiveOutputStream tos = newTarGz(archive)) {
-      TarArchiveEntry entry = new TarArchiveEntry("link", TarConstants.LF_SYMLINK);
-      // symlink target attempts to escape the destination directory
-      entry.setLinkName("../../../../etc/passwd");
-      tos.putArchiveEntry(entry);
-      tos.closeArchiveEntry();
+      addSymlinkEntry(tos, "link", "../../../../etc/passwd");
     }
 
     Path target = tempDir.resolve("out");
@@ -100,6 +135,28 @@ class TarUnArchiverTest {
     assertTrue(ex.getCause().getMessage().contains("outside of the target directory"));
     // symlink itself must not have been created
     assertFalse(Files.exists(target.resolve("link"), java.nio.file.LinkOption.NOFOLLOW_LINKS));
+  }
+
+  /**
+   * A symlink placed in a subdirectory whose target escapes the extraction root
+   * via enough {@code ..} segments must also be rejected.
+   */
+  @Test
+  void testUnarchive_symlinkEscapeFromSubdirRejected(@TempDir Path tempDir) throws IOException {
+    File archive = tempDir.resolve("symlink-subdir-evil.tar.gz").toFile();
+    try (TarArchiveOutputStream tos = newTarGz(archive)) {
+      addDirEntry(tos, "subdir/");
+      // subdir/evil -> ../../../../etc/passwd  (escapes extraction root)
+      addSymlinkEntry(tos, "subdir/evil", "../../../../etc/passwd");
+    }
+
+    Path target = tempDir.resolve("out");
+    Files.createDirectories(target);
+    MojoExecutionException ex = assertThrows(MojoExecutionException.class,
+        () -> new TarUnArchiver(archive).unarchive(target.toString()));
+    assertTrue(ex.getCause() instanceof IOException);
+    assertTrue(ex.getCause().getMessage().contains("outside of the target directory"));
+    assertFalse(Files.exists(target.resolve("subdir/evil"), java.nio.file.LinkOption.NOFOLLOW_LINKS));
   }
 
   private static TarArchiveOutputStream newTarGz(File archive) throws IOException {
@@ -117,6 +174,13 @@ class TarUnArchiverTest {
 
   private static void addDirEntry(TarArchiveOutputStream tos, String name) throws IOException {
     TarArchiveEntry entry = new TarArchiveEntry(name);
+    tos.putArchiveEntry(entry);
+    tos.closeArchiveEntry();
+  }
+
+  private static void addSymlinkEntry(TarArchiveOutputStream tos, String name, String linkTarget) throws IOException {
+    TarArchiveEntry entry = new TarArchiveEntry(name, TarConstants.LF_SYMLINK);
+    entry.setLinkName(linkTarget);
     tos.putArchiveEntry(entry);
     tos.closeArchiveEntry();
   }

--- a/src/test/java/io/wcm/maven/plugins/nodejs/installation/ZipUnArchiverTest.java
+++ b/src/test/java/io/wcm/maven/plugins/nodejs/installation/ZipUnArchiverTest.java
@@ -1,0 +1,117 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2026 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.maven.plugins.nodejs.installation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ZipUnArchiverTest {
+
+  private static final String FILE_CONTENT = "hello zip";
+
+  @Test
+  void testUnarchive_validZip(@TempDir Path tempDir) throws IOException, MojoExecutionException {
+    File archive = tempDir.resolve("test.zip").toFile();
+    try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(archive)) {
+      addDirEntry(zos, "subdir/");
+      addFileEntry(zos, "subdir/file.txt", FILE_CONTENT.getBytes(StandardCharsets.UTF_8));
+      addFileEntry(zos, "root.txt", "root".getBytes(StandardCharsets.UTF_8));
+    }
+
+    Path target = tempDir.resolve("out");
+    Files.createDirectories(target);
+    new ZipUnArchiver(archive).unarchive(target.toString());
+
+    assertTrue(Files.isDirectory(target.resolve("subdir")));
+    assertEquals(FILE_CONTENT, Files.readString(target.resolve("subdir/file.txt")));
+    assertEquals("root", Files.readString(target.resolve("root.txt")));
+    // archive must be deleted after extraction
+    assertFalse(archive.exists());
+  }
+
+  @Test
+  void testUnarchive_zipSlipRejected(@TempDir Path tempDir) throws IOException {
+    File archive = tempDir.resolve("evil.zip").toFile();
+    try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(archive)) {
+      addFileEntry(zos, "../../evil.txt", "boom".getBytes(StandardCharsets.UTF_8));
+    }
+
+    Path target = tempDir.resolve("out");
+    Files.createDirectories(target);
+    MojoExecutionException ex = assertThrows(MojoExecutionException.class,
+        () -> new ZipUnArchiver(archive).unarchive(target.toString()));
+    assertTrue(ex.getCause() instanceof IOException);
+    assertTrue(ex.getCause().getMessage().contains("outside of the target directory"));
+    // No file written outside target
+    assertFalse(Files.exists(tempDir.resolve("evil.txt")));
+    assertFalse(Files.exists(tempDir.getParent().resolve("evil.txt")));
+  }
+
+  @Test
+  void testUnarchive_tooManyEntries(@TempDir Path tempDir) throws IOException {
+    File archive = tempDir.resolve("many.zip").toFile();
+    try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(archive)) {
+      // create more than MAX_ENTRIES empty entries
+      long count = SafeExtract.MAX_ENTRIES + 1;
+      for (long i = 0; i < count; i++) {
+        ZipArchiveEntry e = new ZipArchiveEntry("f" + i);
+        e.setSize(0);
+        zos.putArchiveEntry(e);
+        zos.closeArchiveEntry();
+      }
+    }
+
+    Path target = tempDir.resolve("out");
+    Files.createDirectories(target);
+    MojoExecutionException ex = assertThrows(MojoExecutionException.class,
+        () -> new ZipUnArchiver(archive).unarchive(target.toString()));
+    assertTrue(ex.getCause() instanceof IOException);
+    assertTrue(ex.getCause().getMessage().contains("possible zip bomb"));
+  }
+
+  private static void addFileEntry(ZipArchiveOutputStream zos, String name, byte[] data) throws IOException {
+    ZipArchiveEntry entry = new ZipArchiveEntry(name);
+    entry.setSize(data.length);
+    zos.putArchiveEntry(entry);
+    zos.write(data);
+    zos.closeArchiveEntry();
+  }
+
+  private static void addDirEntry(ZipArchiveOutputStream zos, String name) throws IOException {
+    ZipArchiveEntry entry = new ZipArchiveEntry(name);
+    zos.putArchiveEntry(entry);
+    zos.closeArchiveEntry();
+  }
+
+}


### PR DESCRIPTION
* avoid unhandled return values of java.io.File
* add security handling for TarUnArchiver and ZipUnArchiver to avoid "zip bomb attacks"